### PR TITLE
Surface per-method `description` in `lm methods`

### DIFF
--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -160,7 +160,11 @@ void printMethodsHuman(const std::vector<MethodInfo>& methods) {
         
         out << ")\n";
         out << "  Signature: " << method.signature << "\n";
-        out << "  Invokable: " << (method.isInvokable ? "yes" : "no") << "\n\n";
+        out << "  Invokable: " << (method.isInvokable ? "yes" : "no") << "\n";
+        if (!method.description.isEmpty()) {
+            out << "  Description: " << method.description << "\n";
+        }
+        out << "\n";
     }
 }
 

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -3,6 +3,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QStringList>
 #include <QFileInfo>
 #include <iostream>
 #include <vector>
@@ -162,7 +163,15 @@ void printMethodsHuman(const std::vector<MethodInfo>& methods) {
         out << "  Signature: " << method.signature << "\n";
         out << "  Invokable: " << (method.isInvokable ? "yes" : "no") << "\n";
         if (!method.description.isEmpty()) {
-            out << "  Description: " << method.description << "\n";
+            const QStringList descLines = method.description.split('\n');
+            if (descLines.size() <= 1) {
+                out << "  Description: " << method.description << "\n";
+            } else {
+                out << "  Description:\n";
+                for (const QString& dl : descLines) {
+                    out << "    " << dl << "\n";
+                }
+            }
         }
         out << "\n";
     }

--- a/src/logos_module.cpp
+++ b/src/logos_module.cpp
@@ -18,7 +18,10 @@ QJsonObject MethodInfo::toJson() const {
     obj["signature"] = signature;
     obj["returnType"] = returnType;
     obj["isInvokable"] = isInvokable;
-    
+    if (!description.isEmpty()) {
+        obj["description"] = description;
+    }
+
     if (!parameters.empty()) {
         QJsonArray paramsArray;
         for (const auto& param : parameters) {
@@ -246,6 +249,7 @@ std::vector<MethodInfo> LogosModule::getMethods(QObject* obj, bool excludeBaseCl
                 info.signature = mo["signature"].toString();
                 info.returnType = mo["returnType"].toString();
                 info.isInvokable = mo["isInvokable"].toBool(true);
+                info.description = mo["description"].toString();
                 QJsonArray params = mo["parameters"].toArray();
                 for (const QJsonValue& pv : params) {
                     QJsonObject po = pv.toObject();

--- a/src/logos_module.h
+++ b/src/logos_module.h
@@ -33,8 +33,9 @@ struct MethodInfo {
     QString signature;
     QString returnType;
     bool isInvokable = false;
+    QString description;
     std::vector<ParameterInfo> parameters;
-    
+
     QJsonObject toJson() const;
 };
 


### PR DESCRIPTION
## What

`lm methods` now shows each method's `description` (human output adds a `Description:` line; `--json` adds a `description` field). The value comes from the provider's `getMethods()` introspection — populated by doc comments in the module's impl header (see logos-cpp-sdk PR on branch `parse-method-comments-as-description`).

- `MethodInfo` gains `description`; included in `toJson()`; copied from the provider JSON.
- Legacy `QMetaObject`-only modules carry no comments → no description (graceful).

Part of the coordinated `parse-method-comments-as-description` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)